### PR TITLE
make initial (buggy) conversion to kokkos

### DIFF
--- a/kokkos/Makefile
+++ b/kokkos/Makefile
@@ -2,27 +2,49 @@
 # Makefile for vdb-gpu
 #
 
-# ----- Make Macros -----
+KOKKOS_PATH = /research/jeff/kokkos
+KOKKOS_DEVICES = "OpenMP"
+EXE_NAME = "testing"
 
-# OPTFLAGS  =   -O2
-DEFINES   =
-INCLUDES  =
-STD = -std=c++11 -stdlib=libc++
-CXXFLAGS  =	$(STD) -g -Wall -Wextra -pedantic $(DEFINES) $(OPTFLAGS) $(INCLUDES)
-CXX	  =	clang++
+SRC = $(wildcard *.cpp)
 
-TARGETS = testing
-TESTING_TARGETS = testing.o
+default: build
+	echo "Start Build"
 
-# ----- Make Rules -----
 
-all:	$(TARGETS)
+ifneq (,$(findstring Cuda,$(KOKKOS_DEVICES)))
+CXX = ${KOKKOS_PATH}/config/nvcc_wrapper
+EXE = ${EXE_NAME}.cuda
+KOKKOS_ARCH = "SNB,Kepler35"
+KOKKOS_CUDA_OPTIONS = "enable_lambda"
+else
+CXX = g++
+EXE = ${EXE_NAME}.host
+KOKKOS_ARCH = "SNB"
+endif
 
-testing:    $(TESTING_TARGETS)
-	$(CXX) $(CXXFLAGS) -o testing $(TESTING_TARGETS)
+CXXFLAGS = -O0 -g -std=c++11 -Wall -Wextra -pedantic
+LINK = ${CXX}
+LINKFLAGS =
 
-clean:
-	rm -f $(TARGETS) *.o
+DEPFLAGS = -M
 
-# ------ Dependences (.cpp -> .o using default Makefile rule) -----
-testing.o: testing.cpp coord.hpp utils.hpp vdb.hpp vdb-private.hpp
+HEADERS = $(wildcard *.hpp)
+
+OBJ = $(SRC:.cpp=.o)
+LIB =
+
+include $(KOKKOS_PATH)/Makefile.kokkos
+
+build: $(EXE)
+
+$(EXE): $(OBJ) $(KOKKOS_LINK_DEPENDS)
+	$(LINK) $(KOKKOS_LDFLAGS) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(KOKKOS_LIBS) $(LIB) -o $(EXE)
+
+clean: kokkos-clean
+	rm -f *.o *.cuda *.host
+
+# Compilation rules
+
+%.o:%.cpp $(KOKKOS_CPP_DEPENDS) $(HEADERS)
+	$(CXX) $(KOKKOS_CPPFLAGS) $(KOKKOS_CXXFLAGS) $(CXXFLAGS) $(EXTRA_INC) -c $<

--- a/kokkos/vdb-private.hpp
+++ b/kokkos/vdb-private.hpp
@@ -18,37 +18,43 @@
 #include "utils.hpp"
 #include "vdb.hpp"
 
+#include <Kokkos_Core.hpp>
+
+//#define USE_GCC_ATOMICS
+
 template <uint64_t level0, uint64_t level1, uint64_t level2>
-VDB<level0, level1, level2>::VDB(uint64_t mem_size, uint64_t hashmap_size,
+VDB<level0, level1, level2>::VDB(size_t mem_size, uint64_t hashmap_size,
                                  double background)
     : total_storage_size_(mem_size),
-      vdb_storage_(new InternalData[mem_size]),
+      vdb_storage_("vdb_storage", mem_size),
       HASHMAP_SIZE(hashmap_size),
       BACKGROUND_VALUE(background),
-      num_elements_(HASHMAP_SIZE) {
+      num_elements_("num_elements") {
+    num_elements_() = HASHMAP_SIZE;
     initialize_vdb_storage();
     initialize_hashmap();
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 VDB<level0, level1, level2>::~VDB() {
-    delete[] vdb_storage_;
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 void VDB<level0, level1, level2>::initialize_hashmap() {
     for (uint64_t i = HASHMAP_START; i < HASHMAP_START + HASHMAP_SIZE; ++i) {
-        vdb_storage_[i].index = std::numeric_limits<uint64_t>::max();
+        vdb_storage_(i).index = std::numeric_limits<uint64_t>::max();
     }
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 void VDB<level0, level1, level2>::initialize_vdb_storage() {
-    memset(vdb_storage_, 0, total_storage_size_ * sizeof(InternalData));
+    for (size_t i = 0; i < total_storage_size_; ++i) {
+        vdb_storage_(i).index = 0;
+    }
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
-double VDB<level0, level1, level2>::random_access(const Coord xyz) {
+double VDB<level0, level1, level2>::random_access(const Coord xyz) const {
     // Index to internal node or background
     InternalData node_from_hashmap = get_internal_node_from_hashmap(xyz);
     if (node_from_hashmap.tile_or_value == BACKGROUND_VALUE) {
@@ -76,7 +82,7 @@ double VDB<level0, level1, level2>::random_access(const Coord xyz) {
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
-bool VDB<level0, level1, level2>::random_insert(const Coord xyz, double value) {
+bool VDB<level0, level1, level2>::random_insert(const Coord xyz, double value) const {
     // First, get index to internal node or background
     InternalData node_from_hashmap = get_internal_node_from_hashmap(xyz);
     if (node_from_hashmap.tile_or_value == BACKGROUND_VALUE) {
@@ -107,7 +113,7 @@ bool VDB<level0, level1, level2>::random_insert(const Coord xyz, double value) {
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 InternalData VDB<level0, level1, level2>::get_internal_node_from_hashmap(
-    const Coord xyz) {
+    const Coord xyz) const {
     std::array<uint64_t, 3> rootkey = xyz.get_rootkey(LEVEL2_sLOG2);
     uint64_t hash = Coord::hash(rootkey, HASHMAP_LOG_SIZE);
     uint64_t compressed_xyz = xyz.get_compressed_coord(LEVEL2_sLOG2);
@@ -115,20 +121,20 @@ InternalData VDB<level0, level1, level2>::get_internal_node_from_hashmap(
     uint64_t amount_to_pad = 64 - (size_of_axis * 3);  // Likely 40
     for (uint64_t i = HASHMAP_START; i < HASHMAP_START + HASHMAP_SIZE; ++i) {
         uint64_t index = (hash + i * i) % HASHMAP_SIZE;
-        if (vdb_storage_[index].index != std::numeric_limits<uint64_t>::max()) {
+        if (vdb_storage_(index).index != std::numeric_limits<uint64_t>::max()) {
             // Compare to compressed_xyz to find correct hashmap value
-            uint64_t compressed_xyz_index = vdb_storage_[index].index;
+            uint64_t compressed_xyz_index = vdb_storage_(index).index;
             if (((compressed_xyz_index >> amount_to_pad) << amount_to_pad) ==
                 ((compressed_xyz >> amount_to_pad) << amount_to_pad)) {
                 // TODO: Fix ugly hack
                 uint64_t mask = (1LLU << amount_to_pad) - 1;
-                while ((vdb_storage_[index].index & mask) == mask)
+                while ((vdb_storage_(index).index & mask) == mask)
                     ;
 
                 // Extract last 40 bits
                 InternalData ret;
                 ret.index =
-                    (vdb_storage_[index].index) & ((1LLU << amount_to_pad) - 1);
+                    (vdb_storage_(index).index) & ((1LLU << amount_to_pad) - 1);
                 return ret;
             }
         }
@@ -140,7 +146,7 @@ InternalData VDB<level0, level1, level2>::get_internal_node_from_hashmap(
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 InternalData VDB<level0, level1, level2>::get_internal_or_leaf_node(
-    const Coord xyz, uint64_t index, bool* is_tile, InternalNodeLevel inl) {
+    const Coord xyz, uint64_t index, bool* is_tile, InternalNodeLevel inl) const {
     uint64_t size;
     uint64_t mask_size;
     switch (inl) {
@@ -155,31 +161,32 @@ InternalData VDB<level0, level1, level2>::get_internal_or_leaf_node(
     }
 
     // Pointer to first index into internal data array
-    InternalData* internal_node_array_pointer = vdb_storage_ + index;
+    size_t index_of_internal_node_array = index;
     uint64_t internal_offset = calculate_internal_offset(xyz, inl);
 
     // Spin until ready
-    InternalData* lock_flag_array = internal_node_array_pointer +
-                                    // Length of node array
-                                    size +
-                                    // Length of value mask
-                                    mask_size +
-                                    // Length of child mask
-                                    mask_size;
-    lock_flag_array += internal_offset / NUM_LOCK_FLAGS;
+    size_t index_of_lock_flag_array = index_of_internal_node_array +
+                                      // Length of node array
+                                      size +
+                                      // Length of value mask
+                                      mask_size +
+                                      // Length of child mask
+                                      mask_size;
+    index_of_lock_flag_array += internal_offset / NUM_LOCK_FLAGS;
     uint64_t lock_offset = internal_offset % NUM_LOCK_FLAGS;
-    while (*(reinterpret_cast<uint8_t*>(lock_flag_array) + lock_offset) != DONE)
+    while (*(reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset) != DONE)
         ;
 
-    InternalData internal_node_index =
-        *(internal_node_array_pointer + internal_offset);
+    // JSA This doesn't seem like the right name
+    InternalData returnValue =
+        vdb_storage_(index_of_internal_node_array + internal_offset);
 
     // Check value mask to see if node exists
-    InternalData* value_mask = internal_node_array_pointer +
-                               // Length of node array
-                               size;
-    value_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
-    InternalData value_mask_chunk = *value_mask;
+    size_t index_of_value_mask = index_of_internal_node_array +
+                                 // Length of node array
+                                 size;
+    index_of_value_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
+    InternalData value_mask_chunk = vdb_storage_(index_of_value_mask);
     uint64_t value_mask_offset = internal_offset % INTERNAL_DATA_SIZE;
     if (!extract_bit(value_mask_chunk.index, value_mask_offset)) {
         // If value_mask not set, return background
@@ -188,13 +195,13 @@ InternalData VDB<level0, level1, level2>::get_internal_or_leaf_node(
         return ret;
     }
 
-    InternalData* child_mask = internal_node_array_pointer +
-                               // Length of node array
-                               size +
-                               // Length of value mask
-                               mask_size;
-    child_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
-    InternalData child_mask_chunk = *child_mask;
+    size_t index_of_child_mask = index_of_internal_node_array +
+                                 // Length of node array
+                                 size +
+                                 // Length of value mask
+                                 mask_size;
+    index_of_child_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
+    InternalData child_mask_chunk = vdb_storage_(index_of_child_mask);
 
     uint64_t child_mask_offset = internal_offset % INTERNAL_DATA_SIZE;
     if (!extract_bit(child_mask_chunk.index, child_mask_offset)) {
@@ -203,21 +210,21 @@ InternalData VDB<level0, level1, level2>::get_internal_or_leaf_node(
     }
 
     // Return index or tile, set with boolean flag
-    return internal_node_index;
+    return returnValue;
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 double VDB<level0, level1, level2>::get_value_from_leaf_node(const Coord xyz,
-                                                             uint64_t index) {
-    InternalData* leaf_node_array_pointer = vdb_storage_ + index;
+                                                             uint64_t index) const {
+    size_t index_of_leaf_node_array = index;
     uint64_t leaf_offset = calculate_leaf_offset(xyz);
-    InternalData leaf_node_index = *(leaf_node_array_pointer + leaf_offset);
+    InternalData leaf_node_index = vdb_storage_(index_of_leaf_node_array + leaf_offset);
     // Value mask tracks active states
-    InternalData* value_mask = leaf_node_array_pointer +
-                               // Length of node array
-                               LEVEL0_sSIZE;
-    value_mask += leaf_offset / INTERNAL_DATA_SIZE;
-    InternalData value_mask_chunk = *value_mask;
+    size_t index_of_value_mask = index_of_leaf_node_array +
+                                 // Length of node array
+                                 LEVEL0_sSIZE;
+    index_of_value_mask += leaf_offset / INTERNAL_DATA_SIZE;
+    InternalData value_mask_chunk = vdb_storage_(index_of_value_mask);
     uint64_t value_mask_offset = leaf_offset % INTERNAL_DATA_SIZE;
     if (!extract_bit(value_mask_chunk.index, value_mask_offset)) {
         return BACKGROUND_VALUE;
@@ -228,74 +235,91 @@ double VDB<level0, level1, level2>::get_value_from_leaf_node(const Coord xyz,
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 uint64_t VDB<level0, level1, level2>::insert_internal_or_leaf_node(
-    const Coord xyz, uint64_t index, InternalNodeLevel inl) {
-    uint64_t size;
-    uint64_t mask_size;
-    uint64_t total_size;
-    switch (inl) {
-        case level2_node:
-            size = LEVEL2_sSIZE;
-            mask_size = LEVEL2_MASK_SIZE;
-            total_size = LEVEL1_TOTAL_SIZE;
-            break;
-        case level1_node:
-            size = LEVEL1_sSIZE;
-            mask_size = LEVEL1_MASK_SIZE;
-            total_size = LEVEL0_TOTAL_SIZE;
-            break;
-    }
+    const Coord xyz, uint64_t index, InternalNodeLevel inl) const {
+    const uint64_t size =
+        (inl == level2_node) ? LEVEL2_sSIZE : LEVEL1_sSIZE;
+    const uint64_t mask_size =
+        (inl == level2_node) ? LEVEL2_MASK_SIZE : LEVEL1_MASK_SIZE;
+    const uint64_t total_size =
+        (inl == level2_node) ? LEVEL1_TOTAL_SIZE : LEVEL0_TOTAL_SIZE;
 
     // Pointer to first index into internal data array
-    InternalData* internal_node_array_pointer = vdb_storage_ + index;
+    size_t index_of_internal_node_array = index;
     uint64_t internal_offset = calculate_internal_offset(xyz, inl);
     InternalData& internal_node_index =
-        *(internal_node_array_pointer + internal_offset);
-    InternalData* value_mask = internal_node_array_pointer +
+        vdb_storage_(index_of_internal_node_array + internal_offset);
+    size_t index_of_value_mask = index_of_internal_node_array +
                                // Length of node array
                                size;
-    InternalData* child_mask = internal_node_array_pointer +
+    size_t index_of_child_mask = index_of_internal_node_array +
                                // Length of node array
                                size +
                                // Length of value mask
                                mask_size;
-    InternalData* lock_flag_array = internal_node_array_pointer +
+    size_t index_of_lock_flag_array = index_of_internal_node_array +
                                     // Length of node array
                                     size +
                                     // Length of value mask
                                     mask_size +
                                     // Length of child mask
                                     mask_size;
-    value_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
-    child_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
-    lock_flag_array += internal_offset / NUM_LOCK_FLAGS;
+    index_of_value_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
+    index_of_child_mask += internal_offset / INTERNAL_DATA_SIZE;  // vdb_storage index
+    index_of_lock_flag_array += internal_offset / NUM_LOCK_FLAGS;
 
-    InternalData child_mask_chunk = *child_mask;
+    InternalData child_mask_chunk = vdb_storage_(index_of_child_mask);
     uint64_t mask_offset = internal_offset % INTERNAL_DATA_SIZE;
     uint64_t lock_offset = internal_offset % NUM_LOCK_FLAGS;
     if (!extract_bit(child_mask_chunk.index, mask_offset)) {
         // No internal node child, add an internal node
+        #ifdef USE_GCC_ATOMICS
         uint8_t old_lock_val = __atomic_exchange_n(
-            reinterpret_cast<uint8_t*>(lock_flag_array) + lock_offset, IP,
+            reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset, IP,
             __ATOMIC_SEQ_CST);
+        #else
+        uint8_t old_lock_val = Kokkos::atomic_exchange(
+            reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset, IP);
+        #endif
         if (old_lock_val == READY) {
+            #ifdef USE_GCC_ATOMICS
             uint64_t old_num_elements = __atomic_fetch_add(
-                &num_elements_, total_size, __ATOMIC_SEQ_CST);
+                &num_elements_(), total_size, __ATOMIC_SEQ_CST);
+            #else
+            const uint64_t old_num_elements =
+                Kokkos::atomic_fetch_add(&num_elements_(), total_size);
+            #endif
             internal_node_index.index = old_num_elements;
             uint64_t constant = 1LLU << mask_offset;
-            __atomic_fetch_or(reinterpret_cast<uint64_t*>(value_mask), constant,
+            #ifdef USE_GCC_ATOMICS
+            __atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_value_mask)), constant,
                               __ATOMIC_SEQ_CST);
-            __atomic_fetch_or(reinterpret_cast<uint64_t*>(child_mask), constant,
+            __atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_child_mask)), constant,
                               __ATOMIC_SEQ_CST);
-            *(reinterpret_cast<uint8_t*>(lock_flag_array) + lock_offset) = DONE;
+            *(reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset) = DONE;
+            #else
+            Kokkos::atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_value_mask)), constant);
+            Kokkos::atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_child_mask)), constant);
+            *(reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset) = DONE;
+            #endif
         }  // Else, allocation already in progress
         if (old_lock_val == DONE) {
+            #ifdef USE_GCC_ATOMICS
             __atomic_exchange_n(
-                reinterpret_cast<uint8_t*>(lock_flag_array) + lock_offset, DONE,
+                reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset, DONE,
                 __ATOMIC_SEQ_CST);
+            #else
+            Kokkos::atomic_exchange(
+                reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset, DONE);
+            #endif
         }
     }  // Else, spin until ready
-    while (*(reinterpret_cast<uint8_t*>(lock_flag_array) + lock_offset) != DONE)
+    #ifdef USE_GCC_ATOMICS
+    while (*(reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset) != DONE)
         ;
+    #else
+    while (*(reinterpret_cast<uint8_t*>(&vdb_storage_(index_of_lock_flag_array)) + lock_offset) != DONE)
+        ;
+    #endif
 
     // Return old_num_elements to be used in next iteration
     return internal_node_index.index;
@@ -304,27 +328,31 @@ uint64_t VDB<level0, level1, level2>::insert_internal_or_leaf_node(
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 void VDB<level0, level1, level2>::insert_value_into_leaf_node(const Coord xyz,
                                                               uint64_t index,
-                                                              double value) {
+                                                              double value) const {
     uint64_t leaf_pointer_index = index;
-    InternalData* leaf_node_array_pointer = vdb_storage_ + leaf_pointer_index;
+    size_t index_of_leaf_node_array = leaf_pointer_index;
     uint64_t leaf_offset = calculate_leaf_offset(xyz);
-    InternalData& leaf_node_index = *(leaf_node_array_pointer + leaf_offset);
+    InternalData& leaf_node_index = vdb_storage_(index_of_leaf_node_array + leaf_offset);
     // Isn't currently used, tracks active states
-    InternalData* value_mask = leaf_node_array_pointer +
-                               // Length of node array
-                               LEVEL0_sSIZE;
-    value_mask += leaf_offset / INTERNAL_DATA_SIZE;
+    size_t index_of_value_mask = index_of_leaf_node_array +
+                                 // Length of node array
+                                 LEVEL0_sSIZE;
+    index_of_value_mask += leaf_offset / INTERNAL_DATA_SIZE;
     uint64_t value_mask_offset = leaf_offset % INTERNAL_DATA_SIZE;
     // Multiple threads can update this, the last update wins
     leaf_node_index.tile_or_value = value;
     uint64_t constant = 1LLU << value_mask_offset;
-    __atomic_fetch_or(reinterpret_cast<uint64_t*>(value_mask), constant,
+    #ifdef USE_GCC_ATOMICS
+    __atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_value_mask)), constant,
                       __ATOMIC_SEQ_CST);
+    #else
+    Kokkos::atomic_fetch_or(reinterpret_cast<uint64_t*>(&vdb_storage_(index_of_value_mask)), constant);
+    #endif
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 uint64_t VDB<level0, level1, level2>::insert_internal_node_into_hashmap(
-    const Coord xyz) {
+    const Coord xyz) const {
     std::array<uint64_t, 3> rootkey = xyz.get_rootkey(LEVEL2_sLOG2);
     uint64_t hash = Coord::hash(rootkey, HASHMAP_LOG_SIZE);
     uint64_t compressed_xyz = xyz.get_compressed_coord(LEVEL2_sLOG2);
@@ -334,34 +362,61 @@ uint64_t VDB<level0, level1, level2>::insert_internal_node_into_hashmap(
     for (uint64_t i = HASHMAP_START; i < HASHMAP_START + HASHMAP_SIZE; ++i) {
         uint64_t index = (hash + i * i) % HASHMAP_SIZE;
         uint64_t expected(std::numeric_limits<uint64_t>::max());
-        uint64_t old_val(std::numeric_limits<uint64_t>::max());
         // Use gcc builtin CAS. We must cast the union for the CAS to work.
         // Atomically update storage. We place a temporary value as a lock.
+        #ifdef USE_GCC_ATOMICS
+        uint64_t old_val(std::numeric_limits<uint64_t>::max());
         __atomic_compare_exchange_n(
-            reinterpret_cast<uint64_t*>(vdb_storage_ + index), &old_val,
+            reinterpret_cast<uint64_t*>(&vdb_storage_(index)), &old_val,
             compressed_xyz, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
         // Update index
         if (old_val == expected) {
+        #else
+        bool foundExpected =
+            Kokkos::atomic_compare_exchange_strong(
+                reinterpret_cast<uint64_t*>(&vdb_storage_(index)),
+                expected,
+                compressed_xyz);
+        // Update index
+        if (foundExpected) {
+        #endif
             // Atomically update vdb_storage index
+            #ifdef USE_GCC_ATOMICS
             uint64_t old_num_elements = __atomic_fetch_add(
-                &num_elements_, LEVEL2_TOTAL_SIZE, __ATOMIC_SEQ_CST);
+                &num_elements_(), LEVEL2_TOTAL_SIZE, __ATOMIC_SEQ_CST);
+            #else
+            const uint64_t old_num_elements =
+                Kokkos::atomic_fetch_add(&num_elements_(), LEVEL2_TOTAL_SIZE);
+            #endif
             // Atomically exchange storage value. compressed_xyz_index contains
             // old_num_elements
             uint64_t compressed_xyz_index =
                 ((compressed_xyz >> amount_to_pad) << amount_to_pad) +
                 old_num_elements;
+            #ifdef USE_GCC_ATOMICS
             __atomic_exchange_n(
-                reinterpret_cast<uint64_t*>(vdb_storage_ + index),
+                reinterpret_cast<uint64_t*>(&vdb_storage_(index)),
                 compressed_xyz_index, __ATOMIC_SEQ_CST);
+            #else
+            Kokkos::atomic_exchange(
+                reinterpret_cast<uint64_t*>(&vdb_storage_(index)),
+                compressed_xyz_index);
+            #endif
             return old_num_elements;
         }
+        #ifdef USE_GCC_ATOMICS
+        #else
+        uint64_t old_val = vdb_storage_(index).index;
+        // TODO: I'm not sure this logic holds now, because old_val is
+        //  now not the value we got in the compare and exchange.
+        #endif
         // Spin if we should be storing a value but another thread is.
         if (((old_val >> amount_to_pad) << amount_to_pad) ==
             ((compressed_xyz >> amount_to_pad) << amount_to_pad)) {
             uint64_t mask = (1LLU << amount_to_pad) - 1;
             while ((old_val & mask) == mask) {
                 // TODO: Add thread fence
-                old_val = vdb_storage_[index].index;
+                old_val = vdb_storage_(index).index;
             }
             return (old_val & mask);
         }  // Else, index is occupied and we should continue
@@ -372,22 +427,13 @@ uint64_t VDB<level0, level1, level2>::insert_internal_node_into_hashmap(
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
 uint64_t VDB<level0, level1, level2>::calculate_internal_offset(
-    const Coord xyz, InternalNodeLevel inl) {
-    uint64_t sLog2;
-    uint64_t log2;
-    uint64_t childSLog2;
-    switch (inl) {
-        case level2_node:
-            sLog2 = LEVEL2_sLOG2;
-            log2 = LEVEL2_LOG2;
-            childSLog2 = LEVEL1_sLOG2;
-            break;
-        case level1_node:
-            sLog2 = LEVEL1_sLOG2;
-            log2 = LEVEL1_LOG2;
-            childSLog2 = LEVEL0_sLOG2;
-            break;
-    }
+    const Coord xyz, InternalNodeLevel inl) const {
+    const uint64_t sLog2 =
+        (inl == level2_node) ? LEVEL2_sLOG2 : LEVEL1_sLOG2;
+    const uint64_t log2 =
+        (inl == level2_node) ? LEVEL2_LOG2 : LEVEL1_LOG2;
+    const uint64_t childSLog2 =
+        (inl == level2_node) ? LEVEL1_sLOG2 : LEVEL0_sLOG2;
     uint64_t internalOffset =
         (((xyz.x_ & ((1LLU << sLog2) - 1)) >> childSLog2) << (log2 + log2)) +
         (((xyz.y_ & ((1LLU << sLog2) - 1)) >> childSLog2) << log2) +
@@ -396,7 +442,7 @@ uint64_t VDB<level0, level1, level2>::calculate_internal_offset(
 }
 
 template <uint64_t level0, uint64_t level1, uint64_t level2>
-uint64_t VDB<level0, level1, level2>::calculate_leaf_offset(const Coord xyz) {
+uint64_t VDB<level0, level1, level2>::calculate_leaf_offset(const Coord xyz) const {
     uint64_t leafOffset =
         ((xyz.x_ & ((1LLU << LEVEL0_sLOG2) - 1))
          << (LEVEL0_LOG2 + LEVEL0_LOG2)) +

--- a/kokkos/vdb.hpp
+++ b/kokkos/vdb.hpp
@@ -12,6 +12,8 @@
 
 #include "coord.hpp"
 
+#include <Kokkos_Core.hpp>
+
 union InternalData {
     uint64_t index;                      // Index into vdb storage
     double tile_or_value;                // Tile or Value
@@ -28,7 +30,7 @@ class VDB {
     const uint8_t DONE = 2;
 
     const size_t total_storage_size_;
-    InternalData* vdb_storage_;
+    Kokkos::View<InternalData*> vdb_storage_;
 
     /// Leaf node single-axis  log size (x, y, and z)
     const uint64_t LEVEL0_LOG2 = level0;
@@ -85,28 +87,28 @@ class VDB {
     const double BACKGROUND_VALUE;
 
     /// Keeps track of how many internal datas have been "allocated"
-    uint64_t num_elements_;
+    Kokkos::View<uint64_t> num_elements_;
 
     /// Disabled default constructor
     VDB() = delete;
 
     /// Constructor with memory size parameter
-    VDB(uint64_t mem_size, uint64_t hashmap_size, double background);
+    VDB(size_t mem_size, uint64_t hashmap_size, double background);
 
     /// Destructor
     ~VDB();
 
     /// Disabled copy constructor
-    VDB(VDB& other) = delete;
+    //VDB(VDB& other) = delete;
 
     /// Disabled assignment operator.
     VDB& operator=(VDB& rhs) = delete;
 
     /// Random access into VDB
-    double random_access(const Coord xyz);
+    double random_access(const Coord xyz) const;
 
     /// Random insert into VDB
-    bool random_insert(const Coord xyz, double value);
+    bool random_insert(const Coord xyz, double value) const;
 
    private:
     /// Initializes hashmap with uint64_t max
@@ -117,33 +119,33 @@ class VDB {
 
     /// Gets index to internal node array from hashmap
     /// Will return background value if no node exists at coordinate
-    InternalData get_internal_node_from_hashmap(const Coord xyz);
+    InternalData get_internal_node_from_hashmap(const Coord xyz) const;
 
     /// Access node for a given coordinate
     /// is_tile is set when return value is a tile value
     InternalData get_internal_or_leaf_node(const Coord xyz, uint64_t index,
                                            bool* is_tile,
-                                           InternalNodeLevel inl);
+                                           InternalNodeLevel inl) const;
 
     /// Access value at leaf node for a given coordinate
-    double get_value_from_leaf_node(const Coord xyz, uint64_t index);
+    double get_value_from_leaf_node(const Coord xyz, uint64_t index) const;
 
     /// Inserts internal node index into hashmap atomically
-    uint64_t insert_internal_node_into_hashmap(const Coord xyz);
+    uint64_t insert_internal_node_into_hashmap(const Coord xyz) const;
 
     /// Inserts internal node or leaf node index into tree atomically
     uint64_t insert_internal_or_leaf_node(const Coord xyz, uint64_t index,
-                                          InternalNodeLevel inl);
+                                          InternalNodeLevel inl) const;
 
     /// Inserts value at leaf node
     void insert_value_into_leaf_node(const Coord xyz, uint64_t index,
-                                     double value);
+                                     double value) const;
 
     /// Returns index into internal node array
-    uint64_t calculate_internal_offset(const Coord xyz, InternalNodeLevel inl);
+    uint64_t calculate_internal_offset(const Coord xyz, InternalNodeLevel inl) const;
 
     /// Returns index into leaf node array
-    uint64_t calculate_leaf_offset(const Coord xyz);
+    uint64_t calculate_leaf_offset(const Coord xyz) const;
 };
 
 #include "vdb-private.hpp"


### PR DESCRIPTION
I converted the vdb's storage to kokkos views, converted the atomics to kokkos atomics, and perform the insertions and lookups within a kokkos kernel.  

I've unfortunately introduced a race condition because it sometimes never terminates, but I can't seem to find it and have to move on to other pending projects.  It's probably a good idea to inspect all of my changes line-by-line to make sure I didn't do something silly in the translation process.  You can switch between kokkos atomics and gcc atomics using the #define at the top of vdb-private.hpp to perhaps narrow down the problem.  

Note that I had to make a bunch of functions const which shouldn't logically be const because the vdb is copied by value into the functor, which means it's const within the functor.  I'm not sure what to do about this, but I was just trying to get it working rather than trying to make a final interface.  

You should be able to clone, run "make" within the kokkos subdirectory, then run "./testing.host" in that subdirectory.  If this doesn't compile and run for you on shuffler, tell me.

Sorry I broke it - good luck!